### PR TITLE
Use the correct direct link which does not break the back button

### DIFF
--- a/app.js
+++ b/app.js
@@ -80,7 +80,7 @@ document.on('DOMContentLoaded', function() {
             return `
             <li data-feature='${feat.id}'>
             <label style='border-color: ${color }' title='${title} — ${escape(feat.description)}'>
-                <a href=http://caniuse.com/#${feat.id}>${title}</a>
+                <a href=http://caniuse.com/#feat=${feat.id}>${title}</a>
             </label>
             <span class='pctholder ${(feat.share.difference < 30) ? "lessThan30" : ""}'>
                 <span class=featpct style='background-color:${color}; width: ${pct}'><em>${pct}</em></span>


### PR DESCRIPTION
E.g. `http://caniuse.com/#css-fixed` "redirects" to `http://caniuse.com/#feat=css-fixed`. The back button is now broken (tested in FF and Chrome) because it'll get into a hashchange->redirect loop.

AFAIK the caniuse website is not open source, or else I'd fix it there.
